### PR TITLE
Make chart level visibility user controlled

### DIFF
--- a/AccessDenied.html
+++ b/AccessDenied.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Acceso Denegado</title>
+    <style>
+      :root{--bg:#0b1220;--surface:#0f172a;--text:#e5e7eb;--muted:#94a3b8;--error:#ef4444;--error-bg:#3b0d0d;--error-border:#7f1d1d}
+      *{box-sizing:border-box}html,body{height:100%}
+      body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,Helvetica Neue,Arial;color:var(--text);background:radial-gradient(1200px 600px at 50% -10%,#1e293b 0%,transparent 60%),linear-gradient(180deg,#0b1220 0%,#0b1220 100%);display:flex;align-items:center;justify-content:center;padding:20px}
+      .container{max-width:500px;width:100%;text-align:center}
+      .icon-wrapper{display:inline-flex;align-items:center;justify-content:center;width:80px;height:80px;background:var(--error-bg);border:2px solid var(--error-border);border-radius:50%;margin-bottom:24px}
+      .icon-wrapper svg{color:var(--error)}
+      h1{font-size:28px;font-weight:800;margin:0 0 12px;letter-spacing:.2px}
+      .message{color:var(--muted);font-size:15px;line-height:1.6;margin:0 0 24px}
+      .error-box{background:var(--error-bg);border:1px solid var(--error-border);border-radius:12px;padding:16px;margin:24px 0;text-align:left}
+      .error-box strong{display:block;margin-bottom:8px;color:#fecaca}
+      .error-box p{margin:0;font-size:14px;color:#fca5a5;line-height:1.5}
+      .btn{display:inline-block;padding:12px 24px;background:#3b82f6;color:white;text-decoration:none;border-radius:12px;font-weight:700;transition:.2s}
+      .btn:hover{background:#2563eb}
+      .footer{margin-top:32px;font-size:13px;color:var(--muted)}
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="icon-wrapper">
+        <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="12" cy="12" r="10"></circle>
+          <line x1="15" y1="9" x2="9" y2="15"></line>
+          <line x1="9" y1="9" x2="15" y2="15"></line>
+        </svg>
+      </div>
+
+      <h1><?= title || 'Acceso Denegado' ?></h1>
+
+      <p class="message">No tienes permisos para acceder a esta aplicación.</p>
+
+      <div class="error-box">
+        <strong>Detalles:</strong>
+        <p style="word-break:break-word"><?!= message || 'Tu cuenta no está autorizada para consultar esta información.' ?></p>
+      </div>
+
+      <p class="message">Si crees que deberías tener acceso, contacta al administrador del sistema para que añada tu email a la lista de usuarios autorizados.</p>
+
+      <div class="footer">
+        <p>Consulta de Bandas Salariales · Sistema de Recursos Humanos</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,683 @@
+/**
+ * Configuración centralizada y helpers comunes para la app de visualización
+ * de bandas salariales. VERSIÓN OPTIMIZADA para máximo rendimiento.
+ * 
+ * OPTIMIZACIONES IMPLEMENTADAS:
+ * - Lectura incremental de datos con chunking
+ * - Índices precalculados para filtros rápidos
+ * - Cache inteligente con versionado
+ * - Operaciones batch optimizadas
+ * - Gestión de memoria mejorada
+ */
+
+/********************* CONFIGURACIÓN *********************/
+var CONFIG = Object.freeze({
+  SPREADSHEET_ID: '1LkBuhAu4BZWuCdAEZR6d3Ub5BUfSv3ZsVpRQbACw4n8',
+  DATA_SHEET: 'Laboratorio Carmen',
+  PERMISSIONS_SHEET: 'Permisos',
+  // Configuración de rendimiento
+  CHUNK_SIZE: 1000,           // Procesar datos en chunks de 1000 filas
+  MAX_CACHE_SIZE: 50,         // Máximo 50 entradas en caché
+  CACHE: Object.freeze({
+    PERMISSIONS: 1800,        // 30 minutos
+    FILTERS: 1200,            // 20 minutos
+    DATA: 600,                // 10 minutos
+    INDEXES: 1800             // 30 minutos
+  })
+});
+
+var COLUMN_CANDIDATES = Object.freeze({
+  idxPuesto: ['PuestoDenom','Puesto Denom','Puesto','Puesto denominación','Denominacion de Puesto'],
+  idxNombre: ['Apellidos y nombre','Apellidos y Nombre','Nombre y apellidos','Nombre'],
+  idxSBA: ['SBA 100%','SBA','SBA100%','SBA 100'],
+  idxInicio: ['Inicio Banda','Inicio de banda','Min banda','Minimo banda','Mínimo banda'],
+  idxFinal: ['Final de banda','Final Banda','Max banda','Maximo banda','Máximo banda'],
+  idxMedio: ['Punto Medio Banda','Punto Medio','Midpoint','Pto Medio Banda'],
+  idxDivision: ['DivisionDenom','División','Division','Division Denom'],
+  idxDireccion: ['DireccionDenom','Dirección','Direccion','Direccion Denom'],
+  idxRol: ['RolDenom','Rol Denom','Rol'],
+  idxRolId: ['RolId','Rol Id','RolID','Rol ID'],
+  idxFamilia: ['FamiliaDenom','Familia Denom','Familia'],
+  idxDepartamento: ['DepartDenom','Depart Denom','Departamento'],
+  idxSeccion: ['SeccionDenom','Seccion Denom','Sección','Seccion'],
+  idxEmpresa: ['Empresa','Company','Compañía','Compania'],
+  idxPosicion: ['Posición','Posicion','Position'],
+  idxNivel: ['Nivel','NivelDenom','Nivel Denom','Level']
+});
+
+var FILTER_DEFINITIONS = Object.freeze([
+  { key: 'puesto',       label: 'Puesto',       columnKey: 'idxPuesto',       emptyLabel: 'Todos'  },
+  { key: 'division',     label: 'División',     columnKey: 'idxDivision',     emptyLabel: 'Todas'  },
+  { key: 'direccion',    label: 'Dirección',    columnKey: 'idxDireccion',    emptyLabel: 'Todas'  },
+  { key: 'rol',          label: 'Rol',          columnKey: 'idxRol',          emptyLabel: 'Todos'  },
+  { key: 'familia',      label: 'Familia',      columnKey: 'idxFamilia',      emptyLabel: 'Todas'  },
+  { key: 'departamento', label: 'Departamento', columnKey: 'idxDepartamento', emptyLabel: 'Todos'  },
+  { key: 'seccion',      label: 'Sección',      columnKey: 'idxSeccion',      emptyLabel: 'Todas'  },
+  { key: 'empresa',      label: 'Empresa',      columnKey: 'idxEmpresa',      emptyLabel: 'Todas'  },
+  { key: 'posicion',     label: 'Posición',     columnKey: 'idxPosicion',     emptyLabel: 'Todas'  }
+]);
+
+var SUMMARY_BUCKETS = ['Q0', 'Q1', 'Q2', 'Q3', 'Q4', 'Q5'];
+
+// Niveles directivos que se excluyen del cálculo de R²
+var EXCLUDED_DIRECTOR_LEVELS = Object.freeze([
+  'Corp_Comité de Dirección / Director ejecutivo',
+  'Negocio_Director General',
+  'Negocio_Director Nivel 2',
+  'Negocio_Comité de Dirección / Director ejecutivo',
+  'Sistemas_Comité de Dirección / Director ejecutivo'
+]);
+
+/********************* HELPERS DE CACHE OPTIMIZADOS *********************/
+var CACHE_METADATA = {}; // Track cache size and usage
+
+function getCachedObject_(key) {
+  var raw = CacheService.getScriptCache().get(key);
+  if (raw) {
+    // Update access metadata
+    CACHE_METADATA[key] = CACHE_METADATA[key] || {};
+    CACHE_METADATA[key].lastAccess = Date.now();
+    return JSON.parse(raw);
+  }
+  return null;
+}
+
+function putCachedObject_(key, value, seconds) {
+  try {
+    // Clean up old cache entries if needed
+    cleanupCache_();
+    
+    var serialized = JSON.stringify(value);
+    CacheService.getScriptCache().put(key, serialized, seconds);
+    
+    // Update metadata
+    CACHE_METADATA[key] = {
+      size: serialized.length,
+      created: Date.now(),
+      lastAccess: Date.now()
+    };
+  } catch (err) {
+    Logger.log('No se pudo almacenar en caché "' + key + '": ' + err);
+  }
+}
+
+function cleanupCache_() {
+  var keys = Object.keys(CACHE_METADATA);
+  if (keys.length <= CONFIG.MAX_CACHE_SIZE) return;
+  
+  // Sort by last access time and remove oldest
+  keys.sort(function(a, b) {
+    return (CACHE_METADATA[a].lastAccess || 0) - (CACHE_METADATA[b].lastAccess || 0);
+  });
+  
+  var toRemove = keys.slice(0, keys.length - CONFIG.MAX_CACHE_SIZE);
+  CacheService.getScriptCache().removeAll(toRemove);
+  
+  toRemove.forEach(function(key) {
+    delete CACHE_METADATA[key];
+  });
+}
+
+/********************* AUTENTICACIÓN Y PERMISOS (OPTIMIZADO) *********************/
+function getUserEmail_() {
+  try {
+    var email = Session.getActiveUser().getEmail();
+    if (!email) throw new Error('No se pudo obtener el email del usuario.');
+    return email.toLowerCase().trim();
+  } catch (err) {
+    Logger.log('Error obteniendo email: ' + err);
+    throw new Error('Error de autenticación. Contacta al administrador.');
+  }
+}
+
+function isEmailAuthorized_(email) {
+  var normalized = (email || '').toLowerCase().trim();
+  var cacheKey = 'authorized_emails_v4';
+  var cached = getCachedObject_(cacheKey);
+
+  if (cached) {
+    return !!cached[normalized];
+  }
+
+  try {
+    var sheet = SpreadsheetApp.openById(CONFIG.SPREADSHEET_ID).getSheetByName(CONFIG.PERMISSIONS_SHEET);
+    if (!sheet) {
+      throw new Error("No se encontró la pestaña '" + CONFIG.PERMISSIONS_SHEET + "'.");
+    }
+
+    var lastRow = sheet.getLastRow();
+    var authorizedSet = {};
+
+    if (lastRow > 1) {
+      // OPTIMIZACIÓN: Usar getValues en lugar de múltiples getValue
+      var data = sheet.getRange(2, 1, lastRow - 1, 1).getValues();
+      for (var i = 0; i < data.length; i++) {
+        var em = String(data[i][0] || '').toLowerCase().trim();
+        if (em && em.indexOf('@') > -1) {
+          authorizedSet[em] = true;
+        }
+      }
+    }
+
+    putCachedObject_(cacheKey, authorizedSet, CONFIG.CACHE.PERMISSIONS);
+    return !!authorizedSet[normalized];
+  } catch (err) {
+    Logger.log('Error leyendo permisos: ' + err);
+    throw new Error('Error al verificar permisos.');
+  }
+}
+
+function getAuthorizedEmailsForDebug_() {
+  try {
+    var sheet = SpreadsheetApp.openById(CONFIG.SPREADSHEET_ID).getSheetByName(CONFIG.PERMISSIONS_SHEET);
+    if (!sheet) return [];
+
+    var lastRow = sheet.getLastRow();
+    if (lastRow < 2) return [];
+
+    var data = sheet.getRange(2, 1, lastRow - 1, 1).getValues();
+    var emails = [];
+    for (var i = 0; i < data.length; i++) {
+      var em = String(data[i][0] || '').toLowerCase().trim();
+      if (em && em.indexOf('@') > -1) emails.push(em);
+    }
+    return emails;
+  } catch (err) {
+    Logger.log('Error en getAuthorizedEmailsForDebug_: ' + err);
+    return [];
+  }
+}
+
+/********************* UTILIDADES OPTIMIZADAS *********************/
+var NORMALIZE_CACHE = {};
+var NORMALIZE_CACHE_SIZE = 0;
+var MAX_NORMALIZE_CACHE_SIZE = 1000;
+
+function normalize_(s) {
+  var str = String(s || '');
+  if (NORMALIZE_CACHE[str]) return NORMALIZE_CACHE[str];
+
+  // Clean cache if it gets too large
+  if (NORMALIZE_CACHE_SIZE >= MAX_NORMALIZE_CACHE_SIZE) {
+    NORMALIZE_CACHE = {};
+    NORMALIZE_CACHE_SIZE = 0;
+  }
+
+  var result = str
+    .toLowerCase()
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  NORMALIZE_CACHE[str] = result;
+  NORMALIZE_CACHE_SIZE++;
+  return result;
+}
+
+function toNumberEU_(v) {
+  if (typeof v === 'number') return v;
+  var s = String(v || '').replace(/[\s€]/g, '').replace(/\./g, '').replace(/,/g, '.');
+  var n = parseFloat(s);
+  return isNaN(n) ? NaN : n;
+}
+
+function fmt2_(n) {
+  return isNaN(n) ? '—' : n.toFixed(2).replace('.', ',');
+}
+
+function findHeaderIndex_(headers, candidates) {
+  for (var i = 0; i < candidates.length; i++) {
+    for (var j = 0; j < headers.length; j++) {
+      if (normalize_(headers[j]) === normalize_(candidates[i])) {
+        return j;
+      }
+    }
+  }
+  return -1;
+}
+
+/********************* ACCESO A DATOS OPTIMIZADO *********************/
+function getColumns_(headers) {
+  var cols = {};
+  for (var key in COLUMN_CANDIDATES) {
+    cols[key] = findHeaderIndex_(headers, COLUMN_CANDIDATES[key]);
+  }
+  return cols;
+}
+
+function getSheetAndData_() {
+  var cacheKey = 'sheet_data_v4';
+  var cached = getCachedObject_(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  var sheet = SpreadsheetApp.openById(CONFIG.SPREADSHEET_ID).getSheetByName(CONFIG.DATA_SHEET);
+  if (!sheet) throw new Error("No se encontró la hoja '" + CONFIG.DATA_SHEET + "'.");
+
+  var lastRow = sheet.getLastRow();
+  var lastCol = sheet.getLastColumn();
+  if (lastRow < 2) throw new Error('No hay datos suficientes en la hoja.');
+
+  // OPTIMIZACIÓN: Leer datos en chunks para evitar timeouts
+  var data = [];
+  var chunkSize = CONFIG.CHUNK_SIZE;
+  
+  for (var startRow = 1; startRow <= lastRow; startRow += chunkSize) {
+    var endRow = Math.min(startRow + chunkSize - 1, lastRow);
+    var chunk = sheet.getRange(startRow, 1, endRow - startRow + 1, lastCol).getValues();
+    
+    if (startRow === 1) {
+      data = chunk; // First chunk includes headers
+    } else {
+      data = data.concat(chunk);
+    }
+  }
+
+  var headers = data.shift();
+  var cols = getColumns_(headers);
+
+  var result = { data: data, cols: cols, totalRows: data.length };
+  putCachedObject_(cacheKey, result, CONFIG.CACHE.DATA);
+  return result;
+}
+
+/********************* ÍNDICES PARA FILTROS RÁPIDOS *********************/
+function buildFilterCacheKey_(key) {
+  return 'filter_' + key + '_v8';
+}
+
+function getFilterOptions_() {
+  var cache = CacheService.getScriptCache();
+  var cacheKeys = FILTER_DEFINITIONS.map(function(def) { return buildFilterCacheKey_(def.key); });
+  var cached = cache.getAll(cacheKeys);
+
+  var allPresent = true;
+  for (var i = 0; i < cacheKeys.length; i++) {
+    if (!cached[cacheKeys[i]]) {
+      allPresent = false;
+      break;
+    }
+  }
+
+  if (allPresent) {
+    var cachedResult = {};
+    for (var j = 0; j < FILTER_DEFINITIONS.length; j++) {
+      var def = FILTER_DEFINITIONS[j];
+      cachedResult[def.key] = JSON.parse(cached[buildFilterCacheKey_(def.key)] || '[]');
+      }
+    return cachedResult;
+  }
+
+  // OPTIMIZACIÓN: Procesar datos en chunks para evitar memory overflow
+  var pack = getSheetAndData_();
+  var data = pack.data;
+  var cols = pack.cols;
+
+  var setMap = {};
+  for (var k = 0; k < FILTER_DEFINITIONS.length; k++) {
+    setMap[FILTER_DEFINITIONS[k].key] = {};
+  }
+
+  // Procesar en chunks para mejor rendimiento
+  var chunkSize = CONFIG.CHUNK_SIZE;
+  for (var chunkStart = 0; chunkStart < data.length; chunkStart += chunkSize) {
+    var chunkEnd = Math.min(chunkStart + chunkSize, data.length);
+    
+    for (var r = chunkStart; r < chunkEnd; r++) {
+      var row = data[r];
+      for (var f = 0; f < FILTER_DEFINITIONS.length; f++) {
+        var defn = FILTER_DEFINITIONS[f];
+        var idx = cols[defn.columnKey];
+        if (idx === -1) continue;
+        var val = String(row[idx] || '').trim();
+        if (val) {
+          setMap[defn.key][val] = true;
+        }
+      }
+    }
+    
+    // Pequeña pausa para evitar timeout
+    if (chunkStart % (chunkSize * 5) === 0) {
+      Utilities.sleep(10);
+    }
+  }
+
+  var sortES = function(a, b) { return a.localeCompare(b, 'es'); };
+  var result = {};
+  for (var t = 0; t < FILTER_DEFINITIONS.length; t++) {
+    var def = FILTER_DEFINITIONS[t];
+    var values = Object.keys(setMap[def.key] || {}).sort(sortES);
+    result[def.key] = values;
+    putCachedObject_(buildFilterCacheKey_(def.key), values, CONFIG.CACHE.FILTERS);
+  }
+
+  return result;
+}
+
+/********************* doGet OPTIMIZADO *********************/
+function extractFilters_(params) {
+  var selections = {};
+  for (var i = 0; i < FILTER_DEFINITIONS.length; i++) {
+    var key = FILTER_DEFINITIONS[i].key;
+    selections[key] = params && params[key] ? String(params[key]) : '';
+  }
+  return selections;
+}
+
+function buildTemplateFilters_(selections, options) {
+  var filters = [];
+  for (var i = 0; i < FILTER_DEFINITIONS.length; i++) {
+    var def = FILTER_DEFINITIONS[i];
+    filters.push({
+      key: def.key,
+      label: def.label,
+      emptyLabel: def.emptyLabel,
+      selected: selections[def.key] || '',
+      options: options[def.key] || []
+    });
+  }
+
+  for (var j = 0; j < filters.length; j++) {
+    var filter = filters[j];
+    var queryParts = [];
+    for (var k = 0; k < filters.length; k++) {
+      var current = filters[k];
+      var value = current.key === filter.key ? '' : (current.selected || '');
+      queryParts.push(current.key + '=' + encodeURIComponent(value));
+    }
+    filter.removeQuery = queryParts.join('&');
+  }
+
+  return filters;
+}
+
+function doGet(e) {
+  var userEmail;
+  var debugInfo = [];
+
+  try {
+    userEmail = getUserEmail_();
+    debugInfo.push('Email detectado: ' + userEmail);
+  } catch (err) {
+    debugInfo.push('Error obteniendo email: ' + err.message);
+    return renderAccessDenied_('Error de autenticación', err.message + '<br><br>Debug: ' + debugInfo.join('<br>'));
+  }
+
+  var authorized = false;
+  try {
+    authorized = isEmailAuthorized_(userEmail);
+    debugInfo.push('¿Autorizado?: ' + authorized);
+
+    if (!authorized) {
+      var authorizedList = getAuthorizedEmailsForDebug_();
+      debugInfo.push('Emails autorizados encontrados: ' + authorizedList.length);
+      debugInfo.push('Lista: ' + authorizedList.join(', '));
+    }
+  } catch (err) {
+    debugInfo.push('Error verificando permisos: ' + err.message);
+    return renderAccessDenied_('Error al verificar permisos', err.message + '<br><br>Debug: ' + debugInfo.join('<br>'));
+  }
+
+  if (!authorized) {
+    return renderAccessDenied_(
+      'Acceso denegado',
+      'Tu email (' + userEmail + ') no tiene permisos.<br><br>Debug Info:<br>' + debugInfo.join('<br>')
+    );
+  }
+
+  var params = e && e.parameter ? e.parameter : {};
+  var selections = extractFilters_(params);
+  var hasFilters = false;
+  for (var key in selections) {
+    if (selections[key]) {
+      hasFilters = true;
+      break;
+    }
+  }
+
+  var template = HtmlService.createTemplateFromFile('Index');
+  template.baseUrl = ScriptApp.getService().getUrl();
+  template.userEmail = userEmail;
+  template.hasFilters = hasFilters;
+
+  try {
+    var filterOptions = getFilterOptions_();
+    var templateFilters = buildTemplateFilters_(selections, filterOptions);
+    template.filters = templateFilters;
+
+    var result = hasFilters ? buscarEmpleadosOptimizado_(selections) : { empleados: [], resumen: null };
+    template.empleados = result.empleados;
+    template.resumen = result.resumen;
+    template.errorMsg = '';
+  } catch (err) {
+    template.filters = buildTemplateFilters_(selections, {});
+    template.empleados = [];
+    template.resumen = null;
+    template.errorMsg = 'Error: ' + (err && err.message ? err.message : String(err));
+    Logger.log(err);
+  }
+
+  return template.evaluate()
+    .setTitle('Visualizador de Bandas Salariales')
+    .addMetaTag('viewport', 'width=device-width, initial-scale=1');
+}
+
+/********************* BÚSQUEDA OPTIMIZADA *********************/
+function buscarEmpleados_(selections) {
+  var pack = getSheetAndData_();
+  var data = pack.data;
+  var c = pack.cols;
+
+  if (c.idxPuesto === -1) {
+    throw new Error("La columna 'PuestoDenom' no fue encontrada.");
+  }
+
+  // OPTIMIZACIÓN: Pre-filtrar usando índices si están disponibles
+  var activeFilters = [];
+  for (var i = 0; i < FILTER_DEFINITIONS.length; i++) {
+    var def = FILTER_DEFINITIONS[i];
+    var idx = c[def.columnKey];
+    var value = selections[def.key];
+    if (idx !== -1 && value) {
+      activeFilters.push({ idx: idx, norm: normalize_(value) });
+    }
+  }
+
+  var empleados = [];
+  var counts = {};
+  for (var cIndex = 0; cIndex < SUMMARY_BUCKETS.length; cIndex++) {
+    counts[SUMMARY_BUCKETS[cIndex]] = 0;
+  }
+
+  var costeEquidadNum = 0;
+  var excesoBandaNum = 0;
+  var incompletos = 0;
+
+  // OPTIMIZACIÓN: Procesar en chunks para mejor rendimiento
+  var chunkSize = CONFIG.CHUNK_SIZE;
+  for (var chunkStart = 0; chunkStart < data.length; chunkStart += chunkSize) {
+    var chunkEnd = Math.min(chunkStart + chunkSize, data.length);
+    
+    for (var r = chunkStart; r < chunkEnd; r++) {
+      var row = data[r];
+
+      // Aplicar filtros
+      var match = true;
+      for (var f = 0; f < activeFilters.length; f++) {
+        var filter = activeFilters[f];
+        if (normalize_(row[filter.idx]) !== filter.norm) {
+          match = false;
+          break;
+        }
+      }
+      if (!match) continue;
+
+      // Procesar empleado
+      var nombre = c.idxNombre !== -1 ? row[c.idxNombre] : '';
+      var sba = c.idxSBA !== -1 ? toNumberEU_(row[c.idxSBA]) : NaN;
+      var inicio = c.idxInicio !== -1 ? toNumberEU_(row[c.idxInicio]) : NaN;
+      var finalB = c.idxFinal !== -1 ? toNumberEU_(row[c.idxFinal]) : NaN;
+
+      var medio = NaN;
+      if (c.idxMedio !== -1) {
+        medio = toNumberEU_(row[c.idxMedio]);
+      } else if (!isNaN(inicio) && !isNaN(finalB)) {
+        medio = (inicio + finalB) / 2;
+      }
+
+      var posicionPercent = null;
+      var qLabel = '—';
+      var aviso = '';
+      var rango = finalB - inicio;
+
+      if (!isNaN(sba) && !isNaN(inicio) && !isNaN(finalB) && rango > 0) {
+        posicionPercent = ((sba - inicio) / rango) * 100;
+        posicionPercent = Math.max(0, Math.min(100, posicionPercent));
+
+        if (sba < inicio) {
+          qLabel = 'Q0';
+          costeEquidadNum += (inicio - sba);
+        } else if (sba > finalB) {
+          qLabel = 'Q5';
+          excesoBandaNum += (sba - finalB);
+        } else {
+          var p = posicionPercent;
+          qLabel = p < 25 ? 'Q1' : p < 50 ? 'Q2' : p < 75 ? 'Q3' : 'Q4';
+        }
+
+        counts[qLabel]++;
+      } else {
+        aviso = 'Datos insuficientes para ubicar en banda.';
+        incompletos++;
+      }
+
+      empleados.push({
+        nombre:       nombre,
+        puesto:       c.idxPuesto !== -1 ? row[c.idxPuesto] : '',
+        division:     c.idxDivision !== -1 ? row[c.idxDivision] : '',
+        direccion:    c.idxDireccion !== -1 ? row[c.idxDireccion] : '',
+        rol:          c.idxRol !== -1 ? row[c.idxRol] : '',
+        rolId:        c.idxRolId !== -1 ? row[c.idxRolId] : '',
+        familia:      c.idxFamilia !== -1 ? row[c.idxFamilia] : '',
+        departamento: c.idxDepartamento !== -1 ? row[c.idxDepartamento] : '',
+        seccion:      c.idxSeccion !== -1 ? row[c.idxSeccion] : '',
+        empresa:      c.idxEmpresa !== -1 ? row[c.idxEmpresa] : '',
+        posicion:     c.idxPosicion !== -1 ? row[c.idxPosicion] : '',
+        nivel:        c.idxNivel !== -1 ? row[c.idxNivel] : '',
+        sbaNum:    isNaN(sba) ? null : sba,
+        inicioNum: isNaN(inicio) ? null : inicio,
+        medioNum:  isNaN(medio) ? null : medio,
+        finalNum:  isNaN(finalB) ? null : finalB,
+        sbaStr:    fmt2_(sba),
+        inicioStr: fmt2_(inicio),
+        medioStr:  fmt2_(medio),
+        finalStr:  fmt2_(finalB),
+        posicionStr: posicionPercent === null ? '—' : posicionPercent.toFixed(2).replace('.', ','),
+        posicionNum: posicionPercent === null ? null : Number(posicionPercent.toFixed(2)),
+        qLabel: qLabel,
+        aviso: aviso
+      });
+    }
+    
+    // Pequeña pausa para evitar timeout
+    if (chunkStart % (chunkSize * 3) === 0) {
+      Utilities.sleep(10);
+    }
+  }
+
+  var resumen = {
+    total: empleados.length,
+    posiciones: SUMMARY_BUCKETS.map(function(label) {
+      return { label: label, count: counts[label] };
+    }),
+    costeEquidad: formatCurrency_(costeEquidadNum),
+    excesoBanda: formatCurrency_(excesoBandaNum),
+    incompletos: incompletos
+  };
+
+  return { empleados: empleados, resumen: resumen };
+}
+
+function formatCurrency_(num) {
+  return (Math.round(num * 100) / 100).toLocaleString('es-ES', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+}
+
+/********************* PÁGINA DE ACCESO DENEGADO *********************/
+function renderAccessDenied_(title, message) {
+  var template = HtmlService.createTemplateFromFile('AccessDenied');
+  template.title = title;
+  template.message = message;
+
+  return template.evaluate()
+    .setTitle('Acceso Denegado')
+    .addMetaTag('viewport', 'width=device-width, initial-scale=1');
+}
+
+/********************* FUNCIÓN PARA LIMPIAR CACHE OPTIMIZADA *********************/
+function clearAllCache() {
+  var keys = [
+    'authorized_emails_v4', 'authorized_emails_v3', 'authorized_emails_v2', 'authorized_emails',
+    'sheet_data_v4', 'sheet_data_v3', 'sheet_data_v2', 'sheet_data_v1'
+  ];
+
+  for (var i = 0; i < FILTER_DEFINITIONS.length; i++) {
+    keys.push(buildFilterCacheKey_(FILTER_DEFINITIONS[i].key));
+  }
+
+  keys = keys.concat([
+    // Versiones anteriores de filtros para limpieza retroactiva
+    'filter_puesto_v7', 'filter_division_v7', 'filter_direccion_v7',
+    'filter_rol_v7', 'filter_familia_v7', 'filter_departamento_v7',
+    'filter_seccion_v7', 'filter_empresa_v7', 'filter_posicion_v7',
+    'filter_puesto_v6', 'filter_division_v6', 'filter_direccion_v6',
+    'filter_rol_v6', 'filter_familia_v6', 'filter_departamento_v6',
+    'filter_seccion_v6', 'filter_empresa_v6', 'filter_posicion_v6',
+    'filter_options_v4', 'filter_options_v3', 'filter_options_v2', 'filter_options_v1'
+  ]);
+
+  CacheService.getScriptCache().removeAll(keys);
+  NORMALIZE_CACHE = {};
+  NORMALIZE_CACHE_SIZE = 0;
+  CACHE_METADATA = {};
+  Logger.log('✅ Cache limpiado exitosamente - v8 optimizado');
+}
+
+/********************* FUNCIONES DE MONITOREO *********************/
+function getCacheStats() {
+  var cache = CacheService.getScriptCache();
+  var keys = Object.keys(CACHE_METADATA);
+  
+  var stats = {
+    totalEntries: keys.length,
+    totalSize: 0,
+    entries: []
+  };
+  
+  for (var i = 0; i < keys.length; i++) {
+    var key = keys[i];
+    var meta = CACHE_METADATA[key];
+    stats.totalSize += meta.size || 0;
+    stats.entries.push({
+      key: key,
+      size: meta.size || 0,
+      age: Date.now() - (meta.created || 0),
+      lastAccess: meta.lastAccess || 0
+    });
+  }
+  
+  return stats;
+}
+
+function optimizeCache() {
+  var stats = getCacheStats();
+  Logger.log('Cache Stats: ' + JSON.stringify(stats, null, 2));
+  
+  if (stats.totalEntries > CONFIG.MAX_CACHE_SIZE) {
+    cleanupCache_();
+    Logger.log('Cache cleanup performed');
+  }
+}

--- a/Index.html
+++ b/Index.html
@@ -1,0 +1,718 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Consulta de Bandas Salariales</title>
+    <!-- Select2 CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+    <style>
+      :root{--bg:#0b1220;--surface:#0f172a;--muted:#94a3b8;--text:#e5e7eb;--primary:#3b82f6;--primary-600:#2563eb;--ring:#60a5fa33;--chip:#1f2937;--card-border:#ffffff14}
+      *{box-sizing:border-box}html,body{height:100%}
+      body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,Helvetica Neue,Arial;color:var(--text);background:radial-gradient(1200px 600px at 10% -10%,#1e293b 0%,transparent 60%),radial-gradient(1000px 500px at 110% -10%,#0ea5e9 0%,transparent 60%),linear-gradient(180deg,#0b1220 0%,#0b1220 100%);padding:28px 16px 48px}
+      .container{max-width:1200px;margin:0 auto}
+      .header{display:flex;gap:12px;align-items:center;justify-content:space-between;margin-bottom:16px;flex-wrap:wrap}
+      .app-title{font-weight:800;letter-spacing:.2px;font-size:clamp(20px,3.2vw,28px)}
+      .subtitle{color:var(--muted);font-size:14px}
+      .user-badge{display:flex;align-items:center;gap:8px;padding:8px 12px;background:var(--chip);border:1px solid var(--card-border);border-radius:999px;font-size:13px}
+      .user-badge svg{opacity:.7}
+      .card{background:linear-gradient(180deg,#0f172a 0%,#0b1220 100%);border:1px solid var(--card-border);border-radius:16px;padding:16px;box-shadow:0 6px 20px rgba(0,0,0,.25)}
+      .card+.card{margin-top:14px}
+      .filters-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;margin-bottom:16px}
+      @media (max-width:768px){.filters-grid{grid-template-columns:1fr}}
+      .filter-group{display:flex;flex-direction:column}
+      .label{font-size:12px;color:var(--muted);margin:0 0 6px 2px;font-weight:600}
+      .select{width:100%;padding:12px 14px;border-radius:12px;border:1px solid var(--card-border);background:#0b1220;color:var(--text);outline:none;transition:.2s}
+      .select:focus{border-color:#60a5fa;box-shadow:0 0 0 4px var(--ring)}
+      .actions{display:flex;gap:8px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+      .btn{padding:12px 20px;border-radius:12px;border:1px solid transparent;background:var(--primary);color:white;font-weight:700;cursor:pointer;transition:.2s;white-space:nowrap}
+      .btn:hover{background:var(--primary-600)}.btn:active{transform:translateY(1px)}
+      .btn-ghost{background:transparent;border:1px solid var(--card-border);color:var(--text)}.btn-ghost:hover{background:#101827}
+      .chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:12px}
+      .chip{background:var(--chip);border:1px solid var(--card-border);color:var(--text);padding:6px 10px;border-radius:999px;font-size:12px;display:flex;gap:8px;align-items:center}
+      .chip .x{opacity:.7;cursor:pointer;text-decoration:none;color:inherit}
+      .chip .x:hover{opacity:1}
+      .error{background:#3b0d0d;border:1px solid #7f1d1d;color:#fecaca;padding:12px;border-radius:12px;margin-top:12px}
+      .summary{position:sticky;top:8px;z-index:5;background:linear-gradient(180deg,#0f172a 0%,#0b1220 100%);border:1px solid var(--card-border);border-radius:16px;padding:14px;margin:14px 0 16px;box-shadow:0 6px 20px rgba(0,0,0,.25);backdrop-filter:blur(4px)}
+      .summary-head{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
+      .muted{color:var(--muted)}
+      .kpis{display:grid;grid-template-columns:repeat(6,1fr);gap:8px;margin-top:10px}
+      @media (max-width:920px){.kpis{grid-template-columns:repeat(3,1fr)}}
+      @media (max-width:520px){.kpis{grid-template-columns:repeat(2,1fr)}}
+      .tile{background:#0b1220;border:1px solid var(--card-border);border-radius:14px;padding:10px;text-align:center}
+      .tile .label{color:var(--muted);font-size:12px}.tile .value{font-weight:800;font-size:18px}
+      .footer-kpis{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-top:10px}
+      @media (max-width:740px){.footer-kpis{grid-template-columns:1fr}}
+      .stat{background:#071b11;border:1px solid #14532d;border-radius:14px;padding:12px}.stat h4{margin:0 0 6px;color:#86efac}.stat p{margin:0;font-weight:800}
+      .h2{font-size:18px;font-weight:800;margin:20px 0 8px}
+      .card-emp{display:grid;grid-template-columns:1fr;gap:8px}
+      .emp-head{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px}
+      .name{font-weight:800;font-size:16px}
+      .badges{display:flex;gap:8px;flex-wrap:wrap}
+      .badge{padding:4px 8px;border-radius:999px;font-size:12px;border:1px solid var(--card-border)}
+      .badge.q0{background:#311414;color:#fecaca;border-color:#7f1d1d}
+      .badge.q1{background:#142431;color:#bae6fd;border-color:#075985}
+      .badge.q2{background:#12211c;color:#bbf7d0;border-color:#166534}
+      .badge.q3{background:#1f1a2a;color:#e9d5ff;border-color:#6b21a8}
+      .badge.q4{background:#2a1f1a;color:#fed7aa;border-color:#9a3412}
+      .badge.q5{background:#311414;color:#fecaca;border-color:#7f1d1d}
+      .info{color:var(--muted);font-size:13px}
+      .band-container{width:100%;height:32px;background:linear-gradient(90deg,#10b981,#f59e0b,#ef4444);margin-top:6px;border-radius:8px;position:relative;border:1px solid var(--card-border)}
+      .sba-marker{position:absolute;top:-6px;width:4px;height:44px;background:#93c5fd;border-radius:2px;transform:translateX(-50%);box-shadow:0 0 0 3px rgba(147,197,253,.25)}
+      .band-labels{display:flex;justify-content:space-between;font-size:12px;color:var(--muted);margin-top:6px}
+      .empty{text-align:center;color:var(--muted);padding:36px 12px}
+      .link{color:#93c5fd;text-decoration:none}
+      #viz-card .google-visualization-tooltip{background:#0f172a!important;color:#e5e7eb!important;border:1px solid #334155!important;border-radius:12px!important;padding:10px 12px!important;box-shadow:0 20px 40px rgba(0,0,0,.6)!important;z-index:9999!important}
+      #viz-card .google-visualization-tooltip .tt-title{font-weight:800;margin:0 0 4px;font-size:13px;letter-spacing:.2px}
+      #viz-card .google-visualization-tooltip .tt-row{font-size:12px;opacity:.95}
+      .select2-container--default .select2-selection--single{background:#0b1220;border:1px solid var(--card-border);border-radius:12px;height:48px;padding:10px 14px;color:var(--text)}
+      .select2-container--default .select2-selection--single .select2-selection__rendered{color:var(--text);line-height:28px;padding-left:0}
+      .select2-container--default .select2-selection--single .select2-selection__arrow{height:46px;right:10px}
+      .select2-container--default .select2-selection--single .select2-selection__arrow b{border-color:var(--muted) transparent transparent transparent;border-width:6px 5px 0 5px}
+      .select2-container--default.select2-container--open .select2-selection--single .select2-selection__arrow b{border-color:transparent transparent var(--muted) transparent;border-width:0 5px 6px 5px}
+      .select2-dropdown{background:#0f172a;border:1px solid var(--card-border);border-radius:12px;box-shadow:0 10px 30px rgba(0,0,0,.5)}
+      .select2-container--default .select2-search--dropdown .select2-search__field{background:#0b1220;border:1px solid var(--card-border);border-radius:8px;color:var(--text);padding:8px 12px}
+      .select2-container--default .select2-search--dropdown .select2-search__field:focus{border-color:#60a5fa;outline:none}
+      .select2-container--default .select2-results__option{color:var(--text);padding:10px 14px}
+      .select2-container--default .select2-results__option--highlighted[aria-selected]{background:var(--primary);color:white}
+      .select2-container--default .select2-results__option[aria-selected=true]{background:#1f2937;color:var(--text)}
+      .select2-container--default .select2-results__option--selectable{cursor:pointer}
+      .select2-container--default .select2-results>.select2-results__options{max-height:300px}
+      .select2-container--default.select2-container--focus .select2-selection--single{border-color:#60a5fa;box-shadow:0 0 0 4px var(--ring)}
+      .select2-container{width:100%!important}
+      .select2-selection__placeholder{color:var(--muted)!important}
+      .toggle{display:flex;align-items:center;gap:6px;font-size:13px;color:var(--muted)}
+      .toggle input{accent-color:var(--primary)}
+      .level-toggles{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
+      .level-chip{display:inline-flex;align-items:center;gap:6px;padding:8px 12px;border-radius:12px;border:1px solid var(--card-border);background:var(--chip);color:var(--text);font-size:12px}
+      .level-chip input{accent-color:var(--primary)}
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <div>
+          <div class="app-title">Consulta de Bandas Salariales</div>
+          <div class="subtitle">Filtra por múltiples criterios y visualiza posición por banda con KPIs clave.</div>
+        </div>
+        <div class="user-badge">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
+            <circle cx="12" cy="7" r="4"></circle>
+          </svg>
+          <span><?= userEmail ?></span>
+        </div>
+      </div>
+
+      <div class="card">
+        <form method="GET" action="<?= baseUrl ?>" id="searchForm">
+          <div class="filters-grid">
+            <? (filters || []).forEach(function(filter){ ?>
+              <div class="filter-group">
+                <label class="label" for="<?= filter.key ?>"><?= filter.label ?></label>
+                <select class="select select2-filter" id="<?= filter.key ?>" name="<?= filter.key ?>">
+                  <option value=""><?= filter.emptyLabel ?></option>
+                  <? (filter.options || []).forEach(function(opt){ ?>
+                    <option value="<?= opt ?>" <?= (filter.selected === opt ? 'selected' : '') ?>><?= opt ?></option>
+                  <? }); ?>
+                </select>
+              </div>
+            <? }); ?>
+          </div>
+
+          <div class="actions">
+            <button class="btn" type="submit">Buscar</button>
+            <a class="btn btn-ghost" href="<?= baseUrl ?>">Limpiar Todos</a>
+          </div>
+
+          <div class="chips">
+            <? (filters || []).forEach(function(filter){
+              if (filter.selected) { ?>
+                <span class="chip">
+                  <?= filter.label ?>: <strong><?= filter.selected ?></strong>
+                  <a class="x" href="<?= baseUrl ?>?<?= filter.removeQuery ?>" title="Quitar">✕</a>
+                </span>
+            <? }}); ?>
+          </div>
+
+          <? if (errorMsg) { ?>
+            <div class="error" role="alert"><?= errorMsg ?></div>
+          <? } ?>
+        </form>
+      </div>
+
+      <? if (hasFilters && resumen) { ?>
+        <div class="summary" aria-live="polite">
+          <div class="summary-head">
+            <div class="muted"><strong>Resumen</strong> · Total: <strong><?= resumen.total ?></strong></div>
+            <div class="muted">
+              Coste Equidad: <strong>€ <?= resumen.costeEquidad ?></strong> ·
+              Exceso Banda: <strong>€ <?= resumen.excesoBanda ?></strong> ·
+              Incompletos: <strong><?= resumen.incompletos ?></strong>
+            </div>
+          </div>
+          <div class="kpis">
+            <? (resumen.posiciones || []).forEach(function(item){ ?>
+              <div class="tile">
+                <div class="label"><?= item.label ?></div>
+                <div class="value"><?= item.count ?></div>
+              </div>
+            <? }); ?>
+          </div>
+          <div class="footer-kpis">
+            <div class="stat"><h4>Coste de Equidad (hasta mínimo)</h4><p>€ <?= resumen.costeEquidad ?></p></div>
+            <div class="stat"><h4>Exceso de Banda (sobre máximo)</h4><p>€ <?= resumen.excesoBanda ?></p></div>
+            <div class="stat"><h4>Personas con datos incompletos</h4><p><?= resumen.incompletos ?></p></div>
+          </div>
+        </div>
+      <? } ?>
+
+      <? if (empleados && empleados.length > 1) { ?>
+        <div class="card" id="viz-card">
+          <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:12px">
+            <div style="font-weight:800">Distribución por Nivel</div>
+            <div style="display:flex;gap:12px;align-items:center;flex-wrap:wrap">
+              <div class="muted" style="font-size:13px">Niveles visibles:</div>
+              <div id="levelControls" class="level-toggles" aria-label="Niveles visibles"></div>
+              <button class="btn btn-ghost" type="button" id="downloadFull">Descargar PNG</button>
+              <div class="muted">R: <strong id="rValue">—</strong> · R²: <strong id="r2Value">—</strong> · n: <strong id="nPoints">0</strong></div>
+            </div>
+          </div>
+          <div id="vizWrap" style="position:relative;margin-top:10px">
+            <div id="overlayLayer" style="position:absolute;inset:0;z-index:2;pointer-events:none"></div>
+            <div id="mixedChart" style="height:420px;position:relative;z-index:1"></div>
+          </div>
+          <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:8px" class="muted">
+            <span>Y: SBA 100% · X: Nivel · Cajas Rosas = Empleados en Banda (Q1–Q3) · Línea Azul = Punto Medio por Nivel · Tendencia exponencial · Puntos por Q:</span>
+            <span class="badge q1">Q1</span><span class="badge q2">Q2</span><span class="badge q3">Q3</span><span class="badge q4">Q4</span><span class="badge q0">Q0</span><span class="badge q5">Q5</span>
+          </div>
+        </div>
+      <? } ?>
+
+      <? if (empleados && empleados.length > 0) { ?>
+        <div class="h2">Resultados (<?= empleados.length ?>)</div>
+        <? empleados.forEach(function(emp) { ?>
+          <div class="card card-emp">
+            <div class="emp-head">
+              <div class="name"><?= emp.nombre || '(Sin nombre)' ?></div>
+              <div class="badges">
+                <? if (emp.puesto) { ?><span class="badge">Puesto: <?= emp.puesto ?></span><? } ?>
+                <? if (emp.division) { ?><span class="badge">División: <?= emp.division ?></span><? } ?>
+                <? if (emp.direccion) { ?><span class="badge">Dirección: <?= emp.direccion ?></span><? } ?>
+                <? if (emp.rol) { ?><span class="badge">Rol: <?= emp.rol ?></span><? } ?>
+                <? if (emp.familia) { ?><span class="badge">Familia: <?= emp.familia ?></span><? } ?>
+                <? if (emp.departamento) { ?><span class="badge">Depto: <?= emp.departamento ?></span><? } ?>
+                <? if (emp.seccion) { ?><span class="badge">Sección: <?= emp.seccion ?></span><? } ?>
+                <? if (emp.empresa) { ?><span class="badge">Empresa: <?= emp.empresa ?></span><? } ?>
+                <? if (emp.posicion) { ?><span class="badge">Posición: <?= emp.posicion ?></span><? } ?>
+                <? if (emp.nivel) { ?><span class="badge">Nivel: <?= emp.nivel ?></span><? } ?>
+                <span class="badge q<?= (emp.qLabel||'').toLowerCase() ?>">Q: <?= emp.qLabel ?></span>
+              </div>
+            </div>
+            <div class="info">
+              <strong>SBA 100%:</strong> <?= emp.sbaStr ?> € ·
+              <strong>Posición en banda:</strong> <?= emp.posicionStr ?>%
+            </div>
+            <div class="band-container">
+              <? if (emp.posicionNum !== null) { ?>
+                <div class="sba-marker" style="left:<?= emp.posicionNum ?>%"></div>
+              <? } ?>
+            </div>
+            <div class="band-labels">
+              <span><?= emp.inicioStr ?> €</span><span><?= emp.medioStr ?> €</span><span><?= emp.finalStr ?> €</span>
+            </div>
+            <? if (emp.aviso) { ?><div class="info">⚠️ <?= emp.aviso ?></div><? } ?>
+          </div>
+        <? }); ?>
+      <? } else if (hasFilters) { ?>
+        <div class="card empty">
+          <div style="display:flex;gap:10px;justify-content:center;align-items:center">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>
+            <div>No hay resultados con los filtros aplicados. <a class="link" href="<?= baseUrl ?>">Limpiar filtros</a></div>
+          </div>
+        </div>
+      <? } ?>
+    </div>
+
+    <!-- jQuery (requerido por Select2) -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <!-- Select2 JS -->
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+
+    <script>
+      // Inicializar Select2 con optimizaciones
+      $(document).ready(function() {
+        $('.select2-filter').select2({
+          placeholder: 'Selecciona...',
+          allowClear: true,
+          width: '100%',
+          minimumResultsForSearch: 5,
+          dropdownAutoWidth: false,
+          language: {
+            noResults: function() { return "No se encontraron resultados"; },
+            searching: function() { return "Buscando..."; }
+          }
+        });
+
+        var submitTimeout;
+        $('.select2-filter').on('change', function() {
+          clearTimeout(submitTimeout);
+          submitTimeout = setTimeout(function() {
+            $('#searchForm').submit();
+          }, 100);
+        });
+      });
+    </script>
+
+    <? if (empleados && empleados.length > 1) { ?>
+    <script src="https://www.gstatic.com/charts/loader.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+    <script>
+      (function(){
+        var EMP = <?!= JSON.stringify(empleados) ?>;
+        var EXCLUDED_DIRECTOR_LEVELS = [
+          'Corp_Comité de Dirección / Director ejecutivo',
+          'Negocio_Director General',
+          'Negocio_Director Nivel 2',
+          'Negocio_Comité de Dirección / Director ejecutivo',
+          'Sistemas_Comité de Dirección / Director ejecutivo'
+        ];
+        var hiddenLevels = new Set();
+
+        var QCOL = {
+          Q0: '#ef4444',
+          Q1: '#0ea5e9', 
+          Q2: '#22c55e',
+          Q3: '#8b5cf6',
+          Q4: '#f59e0b',
+          Q5: '#ef4444'
+        };
+
+        var fmtEuro0 = function(n) {
+          return Number.isFinite(n) ? new Intl.NumberFormat('es-ES', {
+            style: 'currency',
+            currency: 'EUR',
+            maximumFractionDigits: 0
+          }).format(n) : '—';
+        };
+
+        var euroToNum = function(s) {
+          if (s == null) return NaN;
+          if (typeof s === 'number') return s;
+          var t = String(s).replace(/[ €]/g, '').replace(/\./g, '').replace(/,/g, '.');
+          var n = parseFloat(t);
+          return isNaN(n) ? NaN : n;
+        };
+
+        var num = function(n) {
+          return (n == null || isNaN(n)) ? NaN : Number(n);
+        };
+
+        var quantile = function(arr, q) {
+          var a = arr.filter(Number.isFinite).sort(function(x, y) { return x - y; });
+          if (!a.length) return NaN;
+          var pos = (a.length - 1) * q;
+          var b = Math.floor(pos);
+          var r = pos - b;
+          return a[b + 1] !== undefined ? a[b] + r * (a[b + 1] - a[b]) : a[b];
+        };
+
+        var median = function(arr) {
+          return quantile(arr, 0.5);
+        };
+
+        var pretty = function(s) {
+          return String(s || '').replace(/_/g, ' ');
+        };
+
+        function pearson(xs, ys) {
+          var n = xs.length;
+          if (n < 2) return {r: null, n: n};
+          var sx = 0, sy = 0, sxx = 0, syy = 0, sxy = 0;
+          for (var i = 0; i < n; i++) {
+            var x = xs[i], y = ys[i];
+            sx += x; sy += y; sxx += x * x; syy += y * y; sxy += x * y;
+          }
+          var mx = sx / n, my = sy / n;
+          var cov = sxy / n - mx * my;
+          var vx = sxx / n - mx * mx;
+          var vy = syy / n - my * my;
+          var d = Math.sqrt(vx * vy);
+          return d === 0 ? {r: null, n: n} : {r: cov / d, n: n};
+        }
+
+        // Procesar datos base
+        var points = [];
+        var nivelesMap = new Map();
+
+        for (var i = 0; i < EMP.length; i++) {
+          var e = EMP[i];
+          var nivel = (e.nivel || '').toString();
+          var sba = num(e.sbaNum ?? euroToNum(e.sbaStr));
+          if (!nivel || !Number.isFinite(sba)) continue;
+
+          var punto = {
+            nivel: nivel,
+            sba: sba,
+            inicio: num(e.inicioNum ?? euroToNum(e.inicioStr)),
+            final: num(e.finalNum ?? euroToNum(e.finalStr)),
+            medio: num(e.medioNum ?? euroToNum(e.medioStr)),
+            pos: num(e.posicionNum),
+            q: e.qLabel || '',
+            nombre: e.nombre || ''
+          };
+
+          points.push(punto);
+          if (!nivelesMap.has(nivel)) nivelesMap.set(nivel, []);
+          nivelesMap.get(nivel).push(punto);
+        }
+
+        function buildChartData(excludedLevels) {
+          var rows = [];
+          var ticks = [];
+          var puntosMedios = [];
+          var niveles = [];
+          var nivelIndex = new Map();
+
+          var nivelesConPuntoMedio = [];
+          var keys = Array.from(nivelesMap.keys());
+          for (var i = 0; i < keys.length; i++) {
+            var nivel = keys[i];
+            if (excludedLevels.has(nivel)) continue;
+            var empleadosNivel = nivelesMap.get(nivel);
+            var puntosMedioNivel = [];
+            for (var j = 0; j < empleadosNivel.length; j++) {
+              var emp = empleadosNivel[j];
+              if (Number.isFinite(emp.medio)) puntosMedioNivel.push(emp.medio);
+            }
+            if (puntosMedioNivel.length > 0) {
+              nivelesConPuntoMedio.push({ nivel: nivel, puntoMedio: median(puntosMedioNivel) });
+            }
+          }
+
+          nivelesConPuntoMedio.sort(function(a, b) { return a.puntoMedio - b.puntoMedio; });
+          niveles = nivelesConPuntoMedio.map(function(item) { return item.nivel; });
+          for (var n = 0; n < niveles.length; n++) {
+            nivelIndex.set(niveles[n], n + 1);
+            ticks.push({ v: n + 1, f: pretty(niveles[n]) });
+          }
+
+          for (var p = 0; p < points.length; p++) {
+            var point = points[p];
+            if (excludedLevels.has(point.nivel)) continue;
+            var x = nivelIndex.get(point.nivel);
+            if (!Number.isFinite(x) || !Number.isFinite(point.sba)) continue;
+            var style = 'point { fill-color: ' + (QCOL[point.q] || '#60a5fa') + '; }';
+            var tip = '<div class="tt"><div class="tt-title">' +
+              (point.nombre || '').replace(/</g, '&lt;').replace(/>/g, '&gt;') +
+              '</div><div class="tt-row">Nivel: ' + pretty(point.nivel) +
+              '</div><div class="tt-row">SBA: ' + fmtEuro0(point.sba) +
+              '</div><div class="tt-row">Posición: ' + (Number.isFinite(point.pos) ? point.pos.toFixed(2) : '—') + '%' +
+              '</div><div class="tt-row">Q: ' + (point.q || '—') + '</div></div>';
+            rows.push([x, point.sba, style, tip]);
+          }
+
+          var xs = [], lys = [];
+          for (var r = 0; r < rows.length; r++) {
+            var row = rows[r];
+            if (row[1] > 0) {
+              xs.push(row[0]);
+              lys.push(Math.log(row[1]));
+            }
+          }
+          var pearsonResult = pearson(xs, lys);
+          var rValue = pearsonResult.r;
+          var r2Value = (rValue == null) ? null : (rValue * rValue);
+
+          return {
+            rows: rows,
+            ticks: ticks,
+            niveles: niveles,
+            nivelIndex: nivelIndex,
+            r: rValue,
+            r2: r2Value,
+            n: pearsonResult.n,
+            puntosMedios: nivelesConPuntoMedio
+          };
+        }
+
+        var chartState = buildChartData(hiddenLevels);
+        var chart, dataTable, options;
+
+        function build() {
+          dataTable = new google.visualization.DataTable();
+          dataTable.addColumn('number', 'Nivel #');
+          dataTable.addColumn('number', 'SBA 100%');
+          dataTable.addColumn({type: 'string', role: 'style'});
+          dataTable.addColumn({type: 'string', role: 'tooltip', p: {html: true}});
+          dataTable.addRows(chartState.rows);
+
+          options = {
+            backgroundColor: 'transparent',
+            legend: {position: 'top', textStyle: {color: '#e5e7eb'}},
+            tooltip: {isHtml: true, trigger: 'focus'},
+            pointSize: 5,
+            trendlines: {
+              0: {
+                type: 'exponential',
+                color: '#a0c3ff',
+                lineWidth: 2,
+                opacity: 0.9,
+                visibleInLegend: true
+              }
+            },
+            hAxis: {
+              title: 'Nivel',
+              ticks: chartState.ticks,
+              showTextEvery: 1,
+              slantedText: true,
+              slantedTextAngle: 30,
+              textStyle: {color: '#e5e7eb', fontSize: 11},
+              titleTextStyle: {color: '#e5e7eb'},
+              viewWindow: {min: 0.5}
+            },
+            vAxis: {
+              title: 'SBA 100% (€)',
+              format: 'short',
+              textStyle: {color: '#e5e7eb'},
+              titleTextStyle: {color: '#e5e7eb'},
+              gridlines: {color: '#1f2937', count: -1},
+              minorGridlines: {color: '#111827'}
+            },
+            chartArea: {left: 70, top: 32, right: 20, bottom: 120}
+          };
+        }
+
+        function draw() {
+          if (!chart) {
+            chart = new google.visualization.ScatterChart(document.getElementById('mixedChart'));
+          }
+          google.visualization.events.removeAllListeners(chart);
+          google.visualization.events.addListener(chart, 'ready', drawOverlay);
+          chart.draw(dataTable, options);
+
+          document.getElementById('rValue').textContent = (chartState.r == null ? '—' : (Math.round(chartState.r * 10000) / 10000).toString());
+          document.getElementById('r2Value').textContent = (chartState.r2 == null ? '—' : (Math.round(chartState.r2 * 10000) / 10000).toString());
+          document.getElementById('nPoints').textContent = String(chartState.n || 0);
+        }
+
+        function init() {
+          build();
+          draw();
+
+          var resizeTimer;
+          var handleResize = function() {
+            clearTimeout(resizeTimer);
+            resizeTimer = setTimeout(function() { build(); draw(); }, 150);
+          };
+          window.addEventListener('resize', handleResize);
+
+          var wrap = document.getElementById('vizWrap');
+          if ('ResizeObserver' in window && wrap) {
+            var ro = new ResizeObserver(handleResize);
+            ro.observe(wrap);
+          }
+
+          var levelControls = document.getElementById('levelControls');
+          if (levelControls) {
+            EXCLUDED_DIRECTOR_LEVELS.forEach(function(level, idx) {
+              var wrapper = document.createElement('label');
+              wrapper.className = 'level-chip';
+              var input = document.createElement('input');
+              input.type = 'checkbox';
+              input.checked = true;
+              input.id = 'lvl-' + idx;
+              input.setAttribute('data-level', level);
+              wrapper.appendChild(input);
+              var span = document.createElement('span');
+              span.textContent = level;
+              wrapper.appendChild(span);
+              levelControls.appendChild(wrapper);
+
+              input.addEventListener('change', function() {
+                if (input.checked) {
+                  hiddenLevels.delete(level);
+                } else {
+                  hiddenLevels.add(level);
+                }
+                chartState = buildChartData(hiddenLevels);
+                build();
+                draw();
+              });
+            });
+          }
+
+          document.getElementById('downloadFull').onclick = function() {
+            var wrap = document.getElementById('vizWrap');
+            setTimeout(function() {
+              html2canvas(wrap, {
+                scale: Math.max(2, window.devicePixelRatio || 1),
+                backgroundColor: null,
+                useCORS: true
+              })
+              .then(function(canvas) {
+                var a = document.createElement('a');
+                a.href = canvas.toDataURL('image/png');
+                a.download = 'nivel_sba.png';
+                document.body.appendChild(a);
+                a.click();
+                a.remove();
+              })
+              .catch(function() {
+                alert('No pude generar la imagen.');
+              });
+            }, 50);
+          };
+        }
+
+        function drawOverlay() {
+          var overlay = document.getElementById('overlayLayer');
+          if (!overlay) return;
+          overlay.innerHTML = '';
+
+          var cli = chart.getChartLayoutInterface();
+          var area = cli.getChartAreaBoundingBox();
+          overlay.style.left = area.left + 'px';
+          overlay.style.top = area.top + 'px';
+          overlay.style.width = area.width + 'px';
+          overlay.style.height = area.height + 'px';
+
+            var group = new Map();
+            for (var i = 0; i < chartState.niveles.length; i++) {
+              group.set(chartState.niveles[i], []);
+            }
+            for (var j = 0; j < points.length; j++) {
+              var point = points[j];
+              if (hiddenLevels.has(point.nivel)) continue;
+              if (point && point.nivel && group.has(point.nivel)) {
+                group.get(point.nivel).push(point);
+              }
+            }
+
+          var spacing = Infinity;
+          for (var k = 1; k < chartState.niveles.length; k++) {
+            var d = cli.getXLocation(chartState.nivelIndex.get(chartState.niveles[k])) - cli.getXLocation(chartState.nivelIndex.get(chartState.niveles[k - 1]));
+            if (d > 0 && d < spacing) spacing = d;
+          }
+          if (!Number.isFinite(spacing)) spacing = area.width / Math.max(1, chartState.niveles.length);
+          var boxW = Math.max(14, spacing * 0.6);
+
+          var midPts = [];
+          for (var n = 0; n < chartState.niveles.length; n++) {
+            var nl = chartState.niveles[n];
+            if (!nl || !group.has(nl)) continue;
+
+            var arr = group.get(nl);
+            if (!arr || !arr.length) continue;
+
+            var empleadosEnBanda = [];
+            for (var t = 0; t < arr.length; t++) {
+              var p = arr[t];
+              if (p && (p.q === 'Q1' || p.q === 'Q2' || p.q === 'Q3')) {
+                empleadosEnBanda.push(p);
+              }
+            }
+
+            if (empleadosEnBanda.length === 0) {
+              var inicioNivel = NaN, finalNivel = NaN;
+              for (var s = 0; s < arr.length; s++) {
+                if (Number.isFinite(arr[s].inicio) && Number.isFinite(arr[s].final)) {
+                  inicioNivel = arr[s].inicio;
+                  finalNivel = arr[s].final;
+                  break;
+                }
+              }
+
+              if (Number.isFinite(inicioNivel) && Number.isFinite(finalNivel)) {
+                var cx = cli.getXLocation(chartState.nivelIndex.get(nl));
+                var yTop = cli.getYLocation(inicioNivel);
+                var yBot = cli.getYLocation(finalNivel);
+
+                var rect = document.createElement('div');
+                rect.style.position = 'absolute';
+                rect.style.left = (cx - area.left - boxW / 2) + 'px';
+                rect.style.top = (Math.min(yTop, yBot) - area.top) + 'px';
+                rect.style.width = boxW + 'px';
+                rect.style.height = Math.max(Math.abs(yBot - yTop), 3) + 'px';
+                rect.style.background = '#ff1e70';
+                rect.style.opacity = '0.3';
+                rect.style.borderRadius = '4px';
+                rect.style.border = '1px dashed #ff1e70';
+                overlay.appendChild(rect);
+              }
+              continue;
+            }
+
+            var sbasEnBanda = [];
+            for (var b = 0; b < empleadosEnBanda.length; b++) {
+              var sba = empleadosEnBanda[b].sba;
+              if (Number.isFinite(sba)) sbasEnBanda.push(sba);
+            }
+            if (sbasEnBanda.length === 0) continue;
+
+            var minSba = Math.min.apply(null, sbasEnBanda);
+            var maxSba = Math.max.apply(null, sbasEnBanda);
+            if (!Number.isFinite(minSba) || !Number.isFinite(maxSba)) continue;
+
+            var cxLevel = cli.getXLocation(chartState.nivelIndex.get(nl));
+            var yTopLevel = cli.getYLocation(minSba);
+            var yBotLevel = cli.getYLocation(maxSba);
+
+            var rectBand = document.createElement('div');
+            rectBand.style.position = 'absolute';
+            rectBand.style.left = (cxLevel - area.left - boxW / 2) + 'px';
+            rectBand.style.top = (Math.min(yTopLevel, yBotLevel) - area.top) + 'px';
+            rectBand.style.width = boxW + 'px';
+            rectBand.style.height = Math.max(Math.abs(yBotLevel - yTopLevel), 3) + 'px';
+            rectBand.style.background = '#ff1e70';
+            rectBand.style.opacity = '0.6';
+            rectBand.style.borderRadius = '4px';
+            rectBand.style.border = '1px solid #ff1e70';
+            overlay.appendChild(rectBand);
+          }
+
+          if (chartState.puntosMedios && chartState.puntosMedios.length > 0) {
+            for (var m = 0; m < chartState.puntosMedios.length; m++) {
+              var pm = chartState.puntosMedios[m];
+              var nivelIndexValue = chartState.nivelIndex.get(pm.nivel);
+              if (!Number.isFinite(nivelIndexValue) || !Number.isFinite(pm.puntoMedio)) continue;
+              var cxMid = cli.getXLocation(nivelIndexValue);
+              var yMid = cli.getYLocation(pm.puntoMedio);
+              if (Number.isFinite(cxMid) && Number.isFinite(yMid)) {
+                midPts.push([cxMid - area.left, yMid - area.top]);
+              }
+            }
+          }
+
+          if (midPts.length > 1) {
+            midPts.sort(function(a, b) { return a[0] - b[0]; });
+            var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+            svg.setAttribute('width', area.width);
+            svg.setAttribute('height', area.height);
+            svg.style.position = 'absolute';
+            svg.style.left = '0';
+            svg.style.top = '0';
+            svg.style.pointerEvents = 'none';
+
+            var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            var pathData = 'M ' + midPts.map(function(p) { return p[0].toFixed(1) + ',' + p[1].toFixed(1); }).join(' L ');
+            path.setAttribute('d', pathData);
+            path.setAttribute('fill', 'none');
+            path.setAttribute('stroke', '#60a5fa');
+            path.setAttribute('stroke-width', '3');
+            path.setAttribute('opacity', '0.9');
+            path.setAttribute('stroke-linecap', 'round');
+            path.setAttribute('stroke-linejoin', 'round');
+            svg.appendChild(path);
+            overlay.appendChild(svg);
+          }
+        }
+
+        google.charts.load('current', {'packages': ['corechart']});
+        google.charts.setOnLoadCallback(init);
+      })();
+    </script>
+    <? } ?>
+  </body>
+</html>

--- a/OptimizationUtils.gs
+++ b/OptimizationUtils.gs
@@ -1,0 +1,443 @@
+/**
+ * Utilidades de optimización avanzada para la aplicación de bandas salariales
+ * Incluye funciones para indexación, paginación y procesamiento asíncrono
+ */
+
+/********************* ÍNDICES AVANZADOS *********************/
+function buildAdvancedIndexes_() {
+  var cacheKey = 'advanced_indexes_v1';
+  var cached = getCachedObject_(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  var pack = getSheetAndData_();
+  var data = pack.data;
+  var cols = pack.cols;
+
+  var indexes = {
+    byPuesto: {},
+    byDivision: {},
+    byDireccion: {},
+    byRol: {},
+    byFamilia: {},
+    byDepartamento: {},
+    bySeccion: {},
+    byEmpresa: {},
+    byPosicion: {},
+    byRolId: {},
+    salaryRanges: {
+      byRol: {},
+      byPuesto: {},
+      byDivision: {}
+    }
+  };
+
+  // Construir índices en chunks
+  var chunkSize = CONFIG.CHUNK_SIZE;
+  for (var chunkStart = 0; chunkStart < data.length; chunkStart += chunkSize) {
+    var chunkEnd = Math.min(chunkStart + chunkSize, data.length);
+    
+    for (var r = chunkStart; r < chunkEnd; r++) {
+      var row = data[r];
+      var rowIndex = r;
+
+      // Índices básicos
+      if (cols.idxPuesto !== -1 && row[cols.idxPuesto]) {
+        var puesto = normalize_(row[cols.idxPuesto]);
+        if (!indexes.byPuesto[puesto]) indexes.byPuesto[puesto] = [];
+        indexes.byPuesto[puesto].push(rowIndex);
+      }
+
+      if (cols.idxDivision !== -1 && row[cols.idxDivision]) {
+        var division = normalize_(row[cols.idxDivision]);
+        if (!indexes.byDivision[division]) indexes.byDivision[division] = [];
+        indexes.byDivision[division].push(rowIndex);
+      }
+
+      if (cols.idxDireccion !== -1 && row[cols.idxDireccion]) {
+        var direccion = normalize_(row[cols.idxDireccion]);
+        if (!indexes.byDireccion[direccion]) indexes.byDireccion[direccion] = [];
+        indexes.byDireccion[direccion].push(rowIndex);
+      }
+
+      if (cols.idxRol !== -1 && row[cols.idxRol]) {
+        var rol = normalize_(row[cols.idxRol]);
+        if (!indexes.byRol[rol]) indexes.byRol[rol] = [];
+        indexes.byRol[rol].push(rowIndex);
+      }
+
+      if (cols.idxFamilia !== -1 && row[cols.idxFamilia]) {
+        var familia = normalize_(row[cols.idxFamilia]);
+        if (!indexes.byFamilia[familia]) indexes.byFamilia[familia] = [];
+        indexes.byFamilia[familia].push(rowIndex);
+      }
+
+      if (cols.idxDepartamento !== -1 && row[cols.idxDepartamento]) {
+        var departamento = normalize_(row[cols.idxDepartamento]);
+        if (!indexes.byDepartamento[departamento]) indexes.byDepartamento[departamento] = [];
+        indexes.byDepartamento[departamento].push(rowIndex);
+      }
+
+      if (cols.idxSeccion !== -1 && row[cols.idxSeccion]) {
+        var seccion = normalize_(row[cols.idxSeccion]);
+        if (!indexes.bySeccion[seccion]) indexes.bySeccion[seccion] = [];
+        indexes.bySeccion[seccion].push(rowIndex);
+      }
+
+      if (cols.idxEmpresa !== -1 && row[cols.idxEmpresa]) {
+        var empresa = normalize_(row[cols.idxEmpresa]);
+        if (!indexes.byEmpresa[empresa]) indexes.byEmpresa[empresa] = [];
+        indexes.byEmpresa[empresa].push(rowIndex);
+      }
+
+      if (cols.idxPosicion !== -1 && row[cols.idxPosicion]) {
+        var posicion = normalize_(row[cols.idxPosicion]);
+        if (!indexes.byPosicion[posicion]) indexes.byPosicion[posicion] = [];
+        indexes.byPosicion[posicion].push(rowIndex);
+      }
+
+      if (cols.idxRolId !== -1 && row[cols.idxRolId]) {
+        var rolId = normalize_(row[cols.idxRolId]);
+        if (!indexes.byRolId[rolId]) indexes.byRolId[rolId] = [];
+        indexes.byRolId[rolId].push(rowIndex);
+      }
+
+      // Índices de rangos salariales
+      var sba = toNumberEU_(row[cols.idxSBA]);
+      var inicio = toNumberEU_(row[cols.idxInicio]);
+      var final = toNumberEU_(row[cols.idxFinal]);
+
+      if (!isNaN(sba) && !isNaN(inicio) && !isNaN(final)) {
+        var rawRol = cols.idxRol !== -1 ? normalize_(row[cols.idxRol]) : '';
+        var rawPuesto = cols.idxPuesto !== -1 ? normalize_(row[cols.idxPuesto]) : '';
+        var rawDivision = cols.idxDivision !== -1 ? normalize_(row[cols.idxDivision]) : '';
+
+        if (rawRol) {
+          if (!indexes.salaryRanges.byRol[rawRol]) {
+            indexes.salaryRanges.byRol[rawRol] = { min: Infinity, max: -Infinity, count: 0, total: 0 };
+          }
+          indexes.salaryRanges.byRol[rawRol].min = Math.min(indexes.salaryRanges.byRol[rawRol].min, inicio);
+          indexes.salaryRanges.byRol[rawRol].max = Math.max(indexes.salaryRanges.byRol[rawRol].max, final);
+          indexes.salaryRanges.byRol[rawRol].count++;
+          indexes.salaryRanges.byRol[rawRol].total += sba;
+        }
+
+        if (rawPuesto) {
+          if (!indexes.salaryRanges.byPuesto[rawPuesto]) {
+            indexes.salaryRanges.byPuesto[rawPuesto] = { min: Infinity, max: -Infinity, count: 0, total: 0 };
+          }
+          indexes.salaryRanges.byPuesto[rawPuesto].min = Math.min(indexes.salaryRanges.byPuesto[rawPuesto].min, inicio);
+          indexes.salaryRanges.byPuesto[rawPuesto].max = Math.max(indexes.salaryRanges.byPuesto[rawPuesto].max, final);
+          indexes.salaryRanges.byPuesto[rawPuesto].count++;
+          indexes.salaryRanges.byPuesto[rawPuesto].total += sba;
+        }
+
+        if (rawDivision) {
+          if (!indexes.salaryRanges.byDivision[rawDivision]) {
+            indexes.salaryRanges.byDivision[rawDivision] = { min: Infinity, max: -Infinity, count: 0, total: 0 };
+          }
+          indexes.salaryRanges.byDivision[rawDivision].min = Math.min(indexes.salaryRanges.byDivision[rawDivision].min, inicio);
+          indexes.salaryRanges.byDivision[rawDivision].max = Math.max(indexes.salaryRanges.byDivision[rawDivision].max, final);
+          indexes.salaryRanges.byDivision[rawDivision].count++;
+          indexes.salaryRanges.byDivision[rawDivision].total += sba;
+        }
+      }
+    }
+
+    // Pequeña pausa para evitar timeout
+    if (chunkStart % (chunkSize * 2) === 0) {
+      Utilities.sleep(10);
+    }
+  }
+
+  putCachedObject_(cacheKey, indexes, CONFIG.CACHE.INDEXES);
+  return indexes;
+}
+
+/********************* BÚSQUEDA OPTIMIZADA CON ÍNDICES *********************/
+function buscarEmpleadosOptimizado_(selections) {
+  var pack = getSheetAndData_();
+  var data = pack.data;
+  var c = pack.cols;
+
+  if (c.idxPuesto === -1) {
+    throw new Error("La columna 'PuestoDenom' no fue encontrada.");
+  }
+
+  // Obtener índices
+  var indexes = buildAdvancedIndexes_();
+
+  // Determinar filas candidatas usando índices
+  var candidateRows = null;
+  var hasActiveFilters = false;
+
+  for (var i = 0; i < FILTER_DEFINITIONS.length; i++) {
+    var def = FILTER_DEFINITIONS[i];
+    var value = selections[def.key];
+    if (!value) continue;
+
+    hasActiveFilters = true;
+    var normalizedValue = normalize_(value);
+    var indexKey = def.columnKey.replace('idx', 'by');
+    
+    if (indexes[indexKey] && indexes[indexKey][normalizedValue]) {
+      var rowsForFilter = indexes[indexKey][normalizedValue];
+      
+      if (candidateRows === null) {
+        candidateRows = new Set(rowsForFilter);
+      } else {
+        var newCandidates = new Set();
+        for (var j = 0; j < rowsForFilter.length; j++) {
+          if (candidateRows.has(rowsForFilter[j])) {
+            newCandidates.add(rowsForFilter[j]);
+          }
+        }
+        candidateRows = newCandidates;
+      }
+    } else {
+      return { empleados: [], resumen: createEmptyResumen_() };
+    }
+  }
+
+  if (!hasActiveFilters) {
+    candidateRows = null;
+  }
+
+  var rowsToProcess = candidateRows ? Array.from(candidateRows) : null;
+
+  return procesarEmpleadosConCandidatos_(data, c, rowsToProcess);
+}
+
+function procesarEmpleadosConCandidatos_(data, cols, candidateRows) {
+  var empleados = [];
+  var counts = {};
+  for (var cIndex = 0; cIndex < SUMMARY_BUCKETS.length; cIndex++) {
+    counts[SUMMARY_BUCKETS[cIndex]] = 0;
+  }
+
+  var costeEquidadNum = 0;
+  var excesoBandaNum = 0;
+  var incompletos = 0;
+
+  var rowsToProcess = candidateRows || [];
+  var shouldProcessAll = candidateRows === null;
+
+  if (shouldProcessAll) {
+    for (var r = 0; r < data.length; r++) {
+      var result = procesarEmpleado_(data[r], r, cols);
+      if (result) {
+        empleados.push(result.empleado);
+        counts[result.qLabel]++;
+        if (result.costeEquidad > 0) costeEquidadNum += result.costeEquidad;
+        if (result.excesoBanda > 0) excesoBandaNum += result.excesoBanda;
+        if (result.incompleto) incompletos++;
+      }
+    }
+  } else {
+    for (var i = 0; i < rowsToProcess.length; i++) {
+      var r = rowsToProcess[i];
+      var result = procesarEmpleado_(data[r], r, cols);
+      if (result) {
+        empleados.push(result.empleado);
+        counts[result.qLabel]++;
+        if (result.costeEquidad > 0) costeEquidadNum += result.costeEquidad;
+        if (result.excesoBanda > 0) excesoBandaNum += result.excesoBanda;
+        if (result.incompleto) incompletos++;
+      }
+    }
+  }
+
+  var resumen = {
+    total: empleados.length,
+    posiciones: SUMMARY_BUCKETS.map(function(label) {
+      return { label: label, count: counts[label] };
+    }),
+    costeEquidad: formatCurrency_(costeEquidadNum),
+    excesoBanda: formatCurrency_(excesoBandaNum),
+    incompletos: incompletos
+  };
+
+  return { empleados: empleados, resumen: resumen };
+}
+
+function procesarEmpleado_(row, rowIndex, cols) {
+  var nombre = cols.idxNombre !== -1 ? row[cols.idxNombre] : '';
+  var sba = cols.idxSBA !== -1 ? toNumberEU_(row[cols.idxSBA]) : NaN;
+  var inicio = cols.idxInicio !== -1 ? toNumberEU_(row[cols.idxInicio]) : NaN;
+  var finalB = cols.idxFinal !== -1 ? toNumberEU_(row[cols.idxFinal]) : NaN;
+
+  var medio = NaN;
+  if (cols.idxMedio !== -1) {
+    medio = toNumberEU_(row[cols.idxMedio]);
+  } else if (!isNaN(inicio) && !isNaN(finalB)) {
+    medio = (inicio + finalB) / 2;
+  }
+
+  var posicionPercent = null;
+  var qLabel = '—';
+  var aviso = '';
+  var rango = finalB - inicio;
+  var costeEquidad = 0;
+  var excesoBanda = 0;
+  var incompleto = false;
+
+  if (!isNaN(sba) && !isNaN(inicio) && !isNaN(finalB) && rango > 0) {
+    posicionPercent = ((sba - inicio) / rango) * 100;
+    posicionPercent = Math.max(0, Math.min(100, posicionPercent));
+
+    if (sba < inicio) {
+      qLabel = 'Q0';
+      costeEquidad = inicio - sba;
+    } else if (sba > finalB) {
+      qLabel = 'Q5';
+      excesoBanda = sba - finalB;
+    } else {
+      var p = posicionPercent;
+      qLabel = p < 25 ? 'Q1' : p < 50 ? 'Q2' : p < 75 ? 'Q3' : 'Q4';
+    }
+  } else {
+    aviso = 'Datos insuficientes para ubicar en banda.';
+    incompleto = true;
+  }
+
+  var empleado = {
+    nombre:       nombre,
+    puesto:       cols.idxPuesto !== -1 ? row[cols.idxPuesto] : '',
+    division:     cols.idxDivision !== -1 ? row[cols.idxDivision] : '',
+    direccion:    cols.idxDireccion !== -1 ? row[cols.idxDireccion] : '',
+    rol:          cols.idxRol !== -1 ? row[cols.idxRol] : '',
+    rolId:        cols.idxRolId !== -1 ? row[cols.idxRolId] : '',
+    familia:      cols.idxFamilia !== -1 ? row[cols.idxFamilia] : '',
+    departamento: cols.idxDepartamento !== -1 ? row[cols.idxDepartamento] : '',
+    seccion:      cols.idxSeccion !== -1 ? row[cols.idxSeccion] : '',
+    empresa:      cols.idxEmpresa !== -1 ? row[cols.idxEmpresa] : '',
+    posicion:     cols.idxPosicion !== -1 ? row[cols.idxPosicion] : '',
+    nivel:        cols.idxNivel !== -1 ? row[cols.idxNivel] : '',
+    sbaNum:    isNaN(sba) ? null : sba,
+    inicioNum: isNaN(inicio) ? null : inicio,
+    medioNum:  isNaN(medio) ? null : medio,
+    finalNum:  isNaN(finalB) ? null : finalB,
+    sbaStr:    fmt2_(sba),
+    inicioStr: fmt2_(inicio),
+    medioStr:  fmt2_(medio),
+    finalStr:  fmt2_(finalB),
+    posicionStr: posicionPercent === null ? '—' : posicionPercent.toFixed(2).replace('.', ','),
+    posicionNum: posicionPercent === null ? null : Number(posicionPercent.toFixed(2)),
+    qLabel: qLabel,
+    aviso: aviso
+  };
+
+  return {
+    empleado: empleado,
+    qLabel: qLabel,
+    costeEquidad: costeEquidad,
+    excesoBanda: excesoBanda,
+    incompleto: incompleto
+  };
+}
+
+function createEmptyResumen_() {
+  return {
+    total: 0,
+    posiciones: SUMMARY_BUCKETS.map(function(label) {
+      return { label: label, count: 0 };
+    }),
+    costeEquidad: formatCurrency_(0),
+    excesoBanda: formatCurrency_(0),
+    incompletos: 0
+  };
+}
+
+/********************* PAGINACIÓN *********************/
+function buscarEmpleadosPaginado_(selections, page, pageSize) {
+  page = page || 1;
+  pageSize = pageSize || 50;
+  
+  var result = buscarEmpleadosOptimizado_(selections);
+  var empleados = result.empleados;
+  
+  var totalPages = Math.ceil(empleados.length / pageSize);
+  var startIndex = (page - 1) * pageSize;
+  var endIndex = Math.min(startIndex + pageSize, empleados.length);
+  
+  var paginatedEmpleados = empleados.slice(startIndex, endIndex);
+  
+  return {
+    empleados: paginatedEmpleados,
+    resumen: result.resumen,
+    pagination: {
+      currentPage: page,
+      totalPages: totalPages,
+      pageSize: pageSize,
+      totalItems: empleados.length,
+      hasNext: page < totalPages,
+      hasPrevious: page > 1
+    }
+  };
+}
+
+/********************* FUNCIONES DE MONITOREO AVANZADO *********************/
+function getPerformanceStats() {
+  var cache = CacheService.getScriptCache();
+  var stats = {
+    cache: getCacheStats(),
+    memory: {
+      normalizeCacheSize: NORMALIZE_CACHE_SIZE,
+      maxNormalizeCacheSize: MAX_NORMALIZE_CACHE_SIZE
+    },
+    config: {
+      chunkSize: CONFIG.CHUNK_SIZE,
+      maxCacheSize: CONFIG.MAX_CACHE_SIZE
+    },
+    timestamp: new Date().toISOString()
+  };
+  
+  return stats;
+}
+
+function clearAllCacheAdvanced() {
+  clearAllCache();
+  
+  var indexKeys = [
+    'advanced_indexes_v1',
+    'salary_ranges_v1',
+    'filter_indexes_v1'
+  ];
+  
+  CacheService.getScriptCache().removeAll(indexKeys);
+  
+  Logger.log('✅ Cache avanzado limpiado exitosamente');
+}
+
+/********************* FUNCIÓN DE PRUEBA DE RENDIMIENTO *********************/
+function testPerformance() {
+  var startTime = Date.now();
+  
+  var dataStart = Date.now();
+  var pack = getSheetAndData_();
+  var dataTime = Date.now() - dataStart;
+  
+  var indexStart = Date.now();
+  var indexes = buildAdvancedIndexes_();
+  var indexTime = Date.now() - indexStart;
+  
+  var filterStart = Date.now();
+  var filters = getFilterOptions_();
+  var filterTime = Date.now() - filterStart;
+  
+  var totalTime = Date.now() - startTime;
+  
+  var results = {
+    dataLoadTime: dataTime + 'ms',
+    indexBuildTime: indexTime + 'ms',
+    filterBuildTime: filterTime + 'ms',
+    totalTime: totalTime + 'ms',
+    dataRows: pack.data.length,
+    indexEntries: Object.keys(indexes.byPuesto).length + Object.keys(indexes.byDivision).length,
+    cacheEntries: Object.keys(CACHE_METADATA).length
+  };
+  
+  Logger.log('Performance Test Results: ' + JSON.stringify(results, null, 2));
+  return results;
+}


### PR DESCRIPTION
## Summary
- add inline checkboxes for niveles directivos so the scatter plot and R² default to include all levels but allow hiding selected ones

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c3cc1acd48322ac3a35d59c1f277e)